### PR TITLE
Minor changes for naming consistency and RSpec 3 compatibility

### DIFF
--- a/infra/test/awspec/lib/ec2_helper.rb
+++ b/infra/test/awspec/lib/ec2_helper.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'awspec'
 require 'aws-sdk'
 
-def named_ec2_instances_in_env(environment_name, name_tag)
+def ec2_instances_named_in_env(environment_name, name_tag)
   filters = [
     { name: 'instance-state-name', values: ['pending', 'running'] },
     { name: 'tag:Environment', values: [environment_name] },

--- a/infra/test/awspec/spec/virtual_machine_spec.rb
+++ b/infra/test/awspec/spec/virtual_machine_spec.rb
@@ -1,7 +1,7 @@
 require 'spin_helper'
 
 context "Application Servers in #{environment_name}" do
-  describe named_ec2_instances_in_env(environment_name, "application_server-#{environment_name}") do
+  describe ec2_instances_named_in_env(environment_name, "application_server-#{environment_name}") do
     it { should have(1).items }
     it { is_expected.to all(exist) }
     it { is_expected.to all(be_running) }

--- a/infra/test/awspec/spec/virtual_machine_spec.rb
+++ b/infra/test/awspec/spec/virtual_machine_spec.rb
@@ -2,7 +2,7 @@ require 'spin_helper'
 
 context "Application Servers in #{environment_name}" do
   describe ec2_instances_named_in_env(environment_name, "application_server-#{environment_name}") do
-    it { should have(1).items }
+    its(:size) { is_expected.to eq 1 }
     it { is_expected.to all(exist) }
     it { is_expected.to all(be_running) }
   end


### PR DESCRIPTION
it { should have(1).items } fails with RSpec 3 with "undefined method `have'"